### PR TITLE
Add role-check middleware for admin and moderation commands

### DIFF
--- a/sentinelmod/handlers/admin.py
+++ b/sentinelmod/handlers/admin.py
@@ -3,8 +3,10 @@ from aiogram import F, Router
 from aiogram.types import Message
 
 from sentinelmod.services.roles import set_user_role
+from sentinelmod.handlers.middleware.role_check import RoleCheckMiddleware
 
 router = Router()
+router.message.middleware(RoleCheckMiddleware("moderator"))
 
 
 @router.message(F.text.startswith("!set_admin"))

--- a/sentinelmod/handlers/middleware/role_check.py
+++ b/sentinelmod/handlers/middleware/role_check.py
@@ -1,0 +1,39 @@
+"""Middleware to enforce minimum user roles for handlers."""
+
+from typing import Any, Awaitable, Callable
+
+from aiogram import BaseMiddleware
+from aiogram.types import Message, TelegramObject
+
+from sentinelmod.services.roles import DEFAULT_ROLES, get_user_role
+
+
+class RoleCheckMiddleware(BaseMiddleware):
+    """Ensure that user has at least ``min_role`` in the chat."""
+
+    def __init__(self, min_role: str) -> None:
+        self.min_role = min_role
+        try:
+            self._min_index = DEFAULT_ROLES.index(min_role)
+        except ValueError:
+            raise ValueError(f"Unknown role: {min_role}") from None
+
+    async def __call__(
+        self,
+        handler: Callable[[TelegramObject, dict[str, Any]], Awaitable[Any]],
+        event: TelegramObject,
+        data: dict[str, Any],
+    ) -> Any:
+        if isinstance(event, Message):
+            role = await get_user_role(event.from_user.id, event.chat.id)
+            if role is None:
+                role_index = 0
+            else:
+                try:
+                    role_index = DEFAULT_ROLES.index(role)
+                except ValueError:
+                    role_index = 0
+            if role_index < self._min_index:
+                await event.reply("Недостаточно прав")
+                return
+        return await handler(event, data)

--- a/sentinelmod/handlers/moderation.py
+++ b/sentinelmod/handlers/moderation.py
@@ -2,8 +2,10 @@ from aiogram import Router, F
 from aiogram.types import Message
 
 from sentinelmod.services import moderation as moderation_service
+from sentinelmod.handlers.middleware.role_check import RoleCheckMiddleware
 
 router = Router()
+router.message.middleware(RoleCheckMiddleware("moderator"))
 
 
 @router.message(F.text.startswith("!warn"))


### PR DESCRIPTION
## Summary
- add `RoleCheckMiddleware` to enforce minimum roles
- require moderator role for moderation and admin routers

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiogram)*

------
https://chatgpt.com/codex/tasks/task_e_68af8702e89c83279964b2a598e8e891