### PR TITLE
Add customizable welcome messages with optional CAPTCHA

### DIFF
--- a/sentinelmod/db/models/__init__.py
+++ b/sentinelmod/db/models/__init__.py
@@ -7,3 +7,4 @@ from .user_chat_association import UserChatAssociation
 from .federation import Federation, FederationChat, FederationBan
 from .filter_trigger import FilterTrigger
 from .moderation_log import ModerationLog
+from .welcome_settings import WelcomeSettings

--- a/sentinelmod/db/models/welcome_settings.py
+++ b/sentinelmod/db/models/welcome_settings.py
@@ -1,0 +1,15 @@
+from sqlalchemy import Boolean, ForeignKey, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from sentinelmod.db.base import Base
+
+
+class WelcomeSettings(Base):
+    """Store welcome message configuration for a chat."""
+
+    __tablename__ = "welcome_settings"
+
+    chat_id: Mapped[int] = mapped_column(ForeignKey("chats.id"), primary_key=True)
+    text_template: Mapped[str | None] = mapped_column(Text, nullable=True)
+    media_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    require_captcha: Mapped[bool] = mapped_column(Boolean, default=False)

--- a/sentinelmod/handlers/admin.py
+++ b/sentinelmod/handlers/admin.py
@@ -3,6 +3,11 @@ from aiogram import F, Router
 from aiogram.types import Message
 
 from sentinelmod.services.roles import set_user_role
+from sentinelmod.services.welcome import (
+    set_welcome_captcha,
+    set_welcome_photo,
+    set_welcome_text,
+)
 from sentinelmod.handlers.middleware.role_check import RoleCheckMiddleware
 
 router = Router()
@@ -18,4 +23,37 @@ async def set_admin(msg: Message) -> None:
     target = msg.reply_to_message.from_user
     await set_user_role(target.id, msg.chat.id, "moderator")
     await msg.reply("Пользователь назначен модератором")
+
+
+@router.message(F.text.startswith("!set_welcome_photo"))
+async def set_welcome_photo_cmd(msg: Message) -> None:
+    """Save photo from replied message as welcome image."""
+    if not msg.reply_to_message or not msg.reply_to_message.photo:
+        await msg.reply("Команда должна быть ответом на сообщение с фото")
+        return
+    file_id = msg.reply_to_message.photo[-1].file_id
+    await set_welcome_photo(msg.chat, file_id)
+    await msg.reply("Фото приветствия сохранено")
+
+
+@router.message(F.text.startswith("!set_welcome_captcha"))
+async def set_welcome_captcha_cmd(msg: Message) -> None:
+    """Enable or disable captcha requirement."""
+    parts = msg.text.split(maxsplit=1)
+    if len(parts) < 2 or parts[1] not in {"on", "off"}:
+        await msg.reply("Использование: !set_welcome_captcha on|off")
+        return
+    await set_welcome_captcha(msg.chat, parts[1] == "on")
+    await msg.reply("CAPTCHA " + ("включена" if parts[1] == "on" else "выключена"))
+
+
+@router.message(F.text.startswith("!set_welcome"))
+async def set_welcome_cmd(msg: Message) -> None:
+    """Set welcome text template."""
+    text = msg.text.removeprefix("!set_welcome").strip()
+    if not text:
+        await msg.reply("Укажите текст приветствия")
+        return
+    await set_welcome_text(msg.chat, text)
+    await msg.reply("Текст приветствия сохранён")
 

--- a/sentinelmod/services/welcome.py
+++ b/sentinelmod/services/welcome.py
@@ -1,12 +1,90 @@
-from aiogram.types import ChatMemberUpdated
+"""Welcome message helpers and settings storage."""
 
-from sentinelmod.services.registration import register_chat, register_user, add_user_to_chat
+from __future__ import annotations
+
+from aiogram.types import Chat, ChatMemberUpdated, User
+
+from sentinelmod.db.base import async_session
+from sentinelmod.db.models.welcome_settings import WelcomeSettings
+from sentinelmod.services.registration import (
+    add_user_to_chat,
+    register_chat,
+    register_user,
+)
+
+
+async def set_welcome_text(chat: Chat, text: str) -> None:
+    """Store welcome text template for a chat."""
+    db_chat = await register_chat(chat)
+    async with async_session() as session:
+        settings = await session.get(WelcomeSettings, db_chat.id)
+        if settings:
+            settings.text_template = text
+        else:
+            settings = WelcomeSettings(chat_id=db_chat.id, text_template=text)
+            session.add(settings)
+        await session.commit()
+
+
+async def set_welcome_photo(chat: Chat, file_id: str) -> None:
+    """Store welcome photo file_id for a chat."""
+    db_chat = await register_chat(chat)
+    async with async_session() as session:
+        settings = await session.get(WelcomeSettings, db_chat.id)
+        if settings:
+            settings.media_id = file_id
+        else:
+            settings = WelcomeSettings(chat_id=db_chat.id, media_id=file_id)
+            session.add(settings)
+        await session.commit()
+
+
+async def set_welcome_captcha(chat: Chat, enabled: bool) -> None:
+    """Enable or disable CAPTCHA challenge for a chat."""
+    db_chat = await register_chat(chat)
+    async with async_session() as session:
+        settings = await session.get(WelcomeSettings, db_chat.id)
+        if settings:
+            settings.require_captcha = enabled
+        else:
+            settings = WelcomeSettings(chat_id=db_chat.id, require_captcha=enabled)
+            session.add(settings)
+        await session.commit()
+
+
+async def get_welcome_settings(chat_db_id: int) -> WelcomeSettings | None:
+    """Retrieve welcome settings for chat by internal DB id."""
+    async with async_session() as session:
+        return await session.get(WelcomeSettings, chat_db_id)
+
+
+def render_welcome_text(template: str, user: User, chat: Chat) -> str:
+    """Replace placeholders in template with real data."""
+    return (
+        template.replace("{user_mention}", user.mention_html())
+        .replace("{chat_title}", chat.title or "")
+    )
 
 
 async def process_new_member(event: ChatMemberUpdated) -> None:
-    """Register user/chat and send a simple welcome message."""
-    await register_chat(event.chat)
+    """Register user/chat and send welcome message according to settings."""
+    db_chat = await register_chat(event.chat)
     user = event.new_chat_member.user
     await register_user(user)
     await add_user_to_chat(user.id, event.chat.id)
-    await event.answer(f"Добро пожаловать, {user.full_name}!")
+
+    settings = await get_welcome_settings(db_chat.id)
+    if not settings or not settings.text_template:
+        await event.answer(f"Добро пожаловать, {user.full_name}!")
+        return
+
+    text = render_welcome_text(settings.text_template, user, event.chat)
+
+    if settings.media_id:
+        await event.bot.send_photo(event.chat.id, settings.media_id, caption=text)
+    else:
+        await event.answer(text)
+
+    if settings.require_captcha:
+        await event.answer("Пожалуйста, подтвердите, что вы человек, ответив '42'.")
+

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True

--- a/tests/test_welcome.py
+++ b/tests/test_welcome.py
@@ -1,0 +1,47 @@
+import os
+import pytest
+
+os.environ.setdefault("BOT_TOKEN", "test")
+os.environ.setdefault("POSTGRES_DSN", "sqlite+aiosqlite:///:memory:")
+
+from aiogram.types import Chat, User
+
+from sentinelmod.db.base import Base, engine
+from sentinelmod.services.registration import register_chat
+from sentinelmod.services.welcome import (
+    get_welcome_settings,
+    render_welcome_text,
+    set_welcome_captcha,
+    set_welcome_photo,
+    set_welcome_text,
+)
+
+
+@pytest.mark.asyncio
+async def test_render_welcome_text():
+    chat = Chat(id=1, type="supergroup", title="Test Chat")
+    user = User(id=5, is_bot=False, first_name="John", last_name="Doe", username="jd")
+    template = "Hello {user_mention} to {chat_title}!"
+    rendered = render_welcome_text(template, user, chat)
+    assert user.full_name in rendered
+    assert chat.title in rendered
+
+
+@pytest.mark.asyncio
+async def test_welcome_settings_persist():
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    chat = Chat(id=100, type="supergroup", title="Persist Chat")
+
+    await set_welcome_text(chat, "Welcome!")
+    await set_welcome_photo(chat, "photo123")
+    await set_welcome_captcha(chat, True)
+
+    db_chat = await register_chat(chat)
+    settings = await get_welcome_settings(db_chat.id)
+
+    assert settings is not None
+    assert settings.text_template == "Welcome!"
+    assert settings.media_id == "photo123"
+    assert settings.require_captcha is True


### PR DESCRIPTION
## Summary
- add WelcomeSettings model to store welcome text, media and captcha flag
- enable admin commands for configuring welcome text, photo and captcha
- send configured welcomes with placeholder parsing and optional captcha prompt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; No module named 'aiogram')*


------
https://chatgpt.com/codex/tasks/task_e_68af88e0c2488327859acd448588692f