### PR TITLE
Enhance moderation command feedback and duration parsing

### DIFF
--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -1,0 +1,28 @@
+import os
+import pytest
+
+os.environ.setdefault("BOT_TOKEN", "test")
+os.environ.setdefault("POSTGRES_DSN", "sqlite+aiosqlite:///:memory:")
+
+from sentinelmod.services.moderation import parse_duration, parse_time_and_reason
+
+
+@pytest.mark.parametrize(
+    "token,expected",
+    [
+        ("10m", 600),
+        ("1h30m", 5400),
+        ("2d5h", 2 * 86400 + 5 * 3600),
+        ("2h5m10s", 2 * 3600 + 5 * 60 + 10),
+        ("bad", None),
+    ],
+)
+async def test_parse_duration(token, expected):
+    assert parse_duration(token) == expected
+
+
+@pytest.mark.asyncio
+async def test_parse_time_and_reason():
+    duration, reason = parse_time_and_reason("1h30m test reason")
+    assert duration == 5400
+    assert reason == "test reason"


### PR DESCRIPTION
## Summary
- allow combined duration formats and add human-readable formatting
- improve moderation responses by showing counts and formatted durations
- add tests for duration parsing and reason splitting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sentinelmod', No module named 'sqlalchemy', No module named 'aiogram')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiogram)*

------
https://chatgpt.com/codex/tasks/task_e_68af983979dc832793de519b7870026f