### PR TITLE
Support Cyrillic duration units in moderation utilities

### DIFF
--- a/sentinelmod/services/moderation.py
+++ b/sentinelmod/services/moderation.py
@@ -30,8 +30,17 @@ def parse_duration(token: str) -> Optional[int]:
     if not token:
         return None
 
-    multipliers = {"s": 1, "m": 60, "h": 3600, "d": 86400}
-    parts = re.findall(r"(\d+)([smhd])", token)
+    multipliers = {
+        "s": 1,
+        "m": 60,
+        "h": 3600,
+        "d": 86400,
+        "с": 1,
+        "м": 60,
+        "ч": 3600,
+        "д": 86400,
+    }
+    parts = re.findall(r"(\d+)([smhdсмчд])", token)
     if not parts or "".join(f"{v}{u}" for v, u in parts) != token:
         return None
     return sum(int(value) * multipliers[unit] for value, unit in parts)

--- a/tests/test_moderation.py
+++ b/tests/test_moderation.py
@@ -14,6 +14,8 @@ from sentinelmod.services.moderation import parse_duration, parse_time_and_reaso
         ("1h30m", 5400),
         ("2d5h", 2 * 86400 + 5 * 3600),
         ("2h5m10s", 2 * 3600 + 5 * 60 + 10),
+        ("1ч30м", 5400),
+        ("2д", 2 * 86400),
         ("bad", None),
     ],
 )
@@ -21,8 +23,15 @@ async def test_parse_duration(token, expected):
     assert parse_duration(token) == expected
 
 
+@pytest.mark.parametrize(
+    "text, expected_duration, expected_reason",
+    [
+        ("1h30m test reason", 5400, "test reason"),
+        ("1ч30м тест", 5400, "тест"),
+    ],
+)
 @pytest.mark.asyncio
-async def test_parse_time_and_reason():
-    duration, reason = parse_time_and_reason("1h30m test reason")
-    assert duration == 5400
-    assert reason == "test reason"
+async def test_parse_time_and_reason(text, expected_duration, expected_reason):
+    duration, reason = parse_time_and_reason(text)
+    assert duration == expected_duration
+    assert reason == expected_reason


### PR DESCRIPTION
## Summary
- allow `parse_duration` to handle Cyrillic unit suffixes alongside Latin ones
- extend moderation parsing tests for Russian units and reasons

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement aiogram)*
- `PYTHONPATH=. pytest tests/test_moderation.py -q` *(fails: ModuleNotFoundError: No module named 'aiogram')*

------
https://chatgpt.com/codex/tasks/task_e_68af99ac63448327a4b16cf53922983c